### PR TITLE
[FIX] install redux logger as project dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "rules": {
+    "no-console": 0
+  },
   "extends": [
     "eslint:recommended",
     "plugin:prettier/recommended",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-scripts": "1.1.4",
     "react-vis": "^1.10.4",
     "redux": "^4.0.0",
+    "redux-logger": "^3.0.6",
     "reselect": "^3.0.1",
     "styled-components": "^3.3.3"
   },
@@ -30,7 +31,6 @@
     "eslint-plugin-react": "^7.10.0",
     "husky": "^1.0.0-rc.13",
     "lint-staged": "^7.2.0",
-    "prettier": "^1.14.0",
-    "redux-logger": "^3.0.6"
+    "prettier": "^1.14.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ injectGlobal`
 `;
 
 const middlewares = [];
-
 if (process.env.NODE_ENV === `development`) {
   const loggerMiddleware = createLogger();
   middlewares.push(loggerMiddleware);


### PR DESCRIPTION
- Not deploying to heroku properly
- Try installing as project dependency but don't include in middlewares in prod